### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 # https://help.github.com/en/categories/automating-your-workflow-with-github-actions
 
 name: CI
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/teamsquad-io/php-event-bus/security/code-scanning/3](https://github.com/teamsquad-io/php-event-bus/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will apply to all jobs in the workflow unless overridden by a job-specific `permissions` block. Since the workflow primarily reads repository contents and does not perform any write operations, we will set `contents: read` as the minimal required permission.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
